### PR TITLE
Bugfix for readonly numerical fields

### DIFF
--- a/js/js-forms.js
+++ b/js/js-forms.js
@@ -2275,19 +2275,24 @@ jspyder.extend.fn("form", function () {
                 
                 $input.filter("input")
                     .on("blur", function (event) {
-                        var $input = js.dom(this).setAttrs({ "data-focus": null });
-                        form.setFieldValue(cfg.name, $input.exportValue());
+                        var attrs = { "readonly": null };
+                        js.dom(this).getAttrs(attrs);
+
+                        if(!attrs["readonly"]) {
+                            var $input = js.dom(this).setAttrs({ "data-focus": null });
+                            form.setFieldValue(cfg.name, $input.exportValue());
+                        }
                         return;
                     })
                     .on("focus", function (event) {
                         var attrs = { "readonly": null };
                         js.dom(this).getAttrs(attrs);
-                        
+
                         if(!attrs["readonly"]) {
                             var $input = js.dom(this).setAttrs({ "data-focus": true });
                             form.setFieldValue(cfg.name, $input.exportValue());
                         }
-                        
+
                         return;
                     });
                     


### PR DESCRIPTION
This commit addresses ticket #64, which identifies an issue where
numerical fields would reset to 0 after focus/losefocus events.

connects to #64 
resolves #64
